### PR TITLE
fix: Type check reporter Cog before invoking function

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -47,6 +47,8 @@ BOT_PREFIX = "?" if env.dev_mode else "!"
 
 
 class PiBotCommandTree(app_commands.CommandTree):
+    client: PiBot
+
     def __init__(self, client: PiBot):
         super().__init__(client)
 
@@ -95,15 +97,17 @@ class PiBotCommandTree(app_commands.CommandTree):
             )
         elif isinstance(error, app_commands.CommandInvokeError):
             message = "This command experienced a general error."
+            if error.original:
+                message += f"\n{error.original}"
 
             # Report error to staff
             reporter_cog = self.client.get_cog("Reporter")
 
-            assert isinstance(reporter_cog, Reporter)
-            await reporter_cog.create_command_error_report(
-                error.original,
-                interaction.command,
-            )
+            if isinstance(reporter_cog, Reporter):
+                await reporter_cog.create_command_error_report(
+                    error.original,
+                    interaction.command,
+                )
 
         elif isinstance(error, app_commands.TransformerError):
             message = "This command experienced a transformer error."

--- a/bot.py
+++ b/bot.py
@@ -108,6 +108,12 @@ class PiBotCommandTree(app_commands.CommandTree):
                     error.original,
                     interaction.command,
                 )
+            else:
+                logger.warning(
+                    "Reporter cog was not of type `Reporter`. Was instead: {}".format(
+                        type(reporter_cog),
+                    ),
+                )
 
         elif isinstance(error, app_commands.TransformerError):
             message = "This command experienced a transformer error."


### PR DESCRIPTION
# Description
Adds type checking to the reporter Cog to prevent exceptioning within the `on_error` error handler.

Exceptioning has caused any command that raised a `CommandInvokeError` exception to timeout with:
```
The application did not respond
```
<img width="489" height="94" alt="image" src="https://github.com/user-attachments/assets/f6bd5c81-19b9-4815-a742-e329a2fbe1dd" />

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
