### PR TITLE
chore: Make `/ping` commands run in DMs only

### DIFF
--- a/commandchecks.py
+++ b/commandchecks.py
@@ -8,6 +8,10 @@ from discord.ext import commands
 from src.discord.globals import ROLE_STAFF, ROLE_VIP
 
 
+def is_in_dms(interaction: discord.Interaction):
+    return isinstance(interaction.channel, discord.DMChannel)
+
+
 def is_in_bot_spam(interaction: discord.Interaction):
     guild = interaction.guild
     assert isinstance(guild, discord.Guild)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord==2.3.2
+discord.py==2.4.0
 webcolors==1.11.1
 requests==2.23.0
 asyncio==3.4.3


### PR DESCRIPTION
# Description
If a ping command is run in any other context, then an ephemeral message is sent to notify the user to use run the command in DMs.

The reason behind this change is to have users enable DM messaging between the bot and themselves to allow for Pi-Bot to send messages without 403ing. Previously, a user could set up pings, but unbeknownst to them, they would not be able to receive any pings due to a privacy limitation.

In a future PR, we will think of the option to change the `/ping` command to be only visible within DMs. See #12 

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [x] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [x] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
