### PR TITLE
chore: Change version schema

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -151,8 +151,10 @@ class PiBot(commands.Bot):
             str,
             dict[str, Any],
         ] = {}  # name differentiation between internal _listeners attribute
-        self.__version__ = "v5.1.0"
+        self.__version__ = "2025.09"
         self.__commit__ = self.get_commit()
+        if self.__commit__:
+            self.__version__ += f"-{self.__commit__}"
         self.session = None
         self.mongo_client = AsyncIOMotorClient(
             env.mongo_url,

--- a/bot.py
+++ b/bot.py
@@ -169,7 +169,8 @@ class PiBot(commands.Bot):
         ) as proc:
             if proc.stdout:
                 hash = proc.stdout.read()
-                return hash.decode("utf-8")
+                commit = hash.decode("utf-8")
+                return commit.strip("\n")
         return None
 
     async def setup_hook(self) -> None:

--- a/src/discord/membercommands.py
+++ b/src/discord/membercommands.py
@@ -378,7 +378,7 @@ class MemberCommands(commands.Cog):
         avatar_url = self.bot.user.display_avatar.url
 
         embed = discord.Embed(
-            title=f"**Pi-Bot {self.bot.__version__}**",
+            title=f"**Pi-Bot {self.bot.__version__}{'-dev' if env.dev_mode else ''}**",
             color=discord.Color(0xF86D5F),
             description="""
             Hey there! I'm Pi-Bot, and I help to manage the Scioly.org forums, wiki, and chat. You'll often see me around this Discord server to help users get roles and information about Science Olympiad.


### PR DESCRIPTION
# Description
The semver schema for user-facing products does not make sense to a consumer compared to a developer. Semver versioning should communicate how big changes are so that developers are aware ahead of time before upgrading.

Having the version schema be `year.month-commit` gives a little perspective on when the version of the bot was released and *exactly* what commit the bot is running on. This is great for developers, since bisecting issues becomes a whole lot easier when issues get reported.

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [x] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
