### PR TITLE
feat: Add member role save and restoration on member leave and join

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -190,6 +190,7 @@ class PiBot(commands.Bot):
                 src.mongo.models.Event,
                 src.mongo.models.Censor,
                 src.mongo.models.Settings,
+                src.mongo.models.UserRoles,
                 # TODO
             ],
         )
@@ -210,6 +211,7 @@ class PiBot(commands.Bot):
             "src.discord.spam",
             "src.discord.reporter",
             "src.discord.logger",
+            "src.discord.rolerestore",
         )
         for i, extension in enumerate(extensions):
             try:

--- a/src/discord/rolerestore.py
+++ b/src/discord/rolerestore.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from beanie.odm.operators.update.general import Set
+from discord import Member, RawMemberRemoveEvent
+from discord.ext import commands
+
+from src.discord.globals import (
+    ROLE_EM,
+    ROLE_LH,
+    ROLE_MUTED,
+    ROLE_QUARANTINE,
+    ROLE_SELFMUTE,
+    ROLE_STAFF,
+    ROLE_VIP,
+)
+from src.mongo.models import UserRoles
+
+if TYPE_CHECKING:
+    from bot import PiBot
+
+NON_PUBLIC_ROLES = [
+    # Note that any role above `Bot` or `Pi-Bot` will not be assignable by the bot. This essentially
+    # means any Staff role is not assignable and existing staff must assign the user those roles manually.
+    ROLE_LH,
+    ROLE_EM,
+    ROLE_MUTED,
+    ROLE_SELFMUTE,
+    ROLE_QUARANTINE,
+]
+
+
+class RoleRestore(commands.Cog):
+    """
+    Cog responsible for maintaining members roles when they leave and rejoin. This is in particular
+    to *awarded* roles and not roles that are publicly assignable.
+    """
+
+    def __init__(self, bot: PiBot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_raw_member_remove(self, payload: RawMemberRemoveEvent):
+        if isinstance(payload.user, discord.User):
+            # figure out if we can find member here
+            # the payload type .user can be User | Member, but this should only be called when the member leaves a Guild??
+            return
+
+        roles_to_save = [
+            role.name for role in payload.user.roles if role.name in NON_PUBLIC_ROLES
+        ]
+
+        await UserRoles.find_one(
+            UserRoles.user_id == payload.user.id,
+            UserRoles.guild_id == payload.guild_id,
+        ).upsert(
+            Set({UserRoles.roles: roles_to_save}),
+            on_insert=UserRoles(
+                user_id=payload.user.id,
+                guild_id=payload.guild_id,
+                roles=roles_to_save,
+            ),
+        )
+
+        logging.info(
+            "%d roles were saved for `%s` (id: %d)",
+            len(roles_to_save),
+            payload.user.name,
+            payload.user.id,
+        )
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: Member):
+        user_roles = await UserRoles.find_one(
+            UserRoles.user_id == member.id,
+            UserRoles.guild_id == member.guild.id,
+        )
+
+        if user_roles:
+            roles_to_add = []
+            for role_name in user_roles.roles:
+                role = discord.utils.get(member.guild.roles, name=role_name)
+                roles_to_add.append(role)
+
+            await member.add_roles(
+                *roles_to_add,
+                reason="Existing user rejoined. Restoring non-public roles.",
+            )
+
+
+async def setup(bot: PiBot):
+    await bot.add_cog(RoleRestore(bot))

--- a/src/mongo/models.py
+++ b/src/mongo/models.py
@@ -94,3 +94,13 @@ class Settings(Document):
     class Settings:
         name = "settings"
         use_cache = True
+
+
+class UserRoles(Document):
+    user_id: int
+    guild_id: int
+    roles: list[str]
+
+    class Settings:
+        name = "user_roles"
+        use_cache = False


### PR DESCRIPTION
# Description
Allows for users' roles to be saved upon user leave and then restored upon user rejoin.

Please note that this feature is intended to only restore non-publicly assignable roles (i.e. roles that cannot be assigned via the onboarding survey). Some examples of roles that are non-publicly assignable include but are not limited to `Exalted`, `Automation Development Subgroup`, `Muted`, and `Quarantine`.

Currently, these roles are hard-coded into a list. Ideally, this list should be able to be changed during runtime, so consideration of making it its own database table is not out of the question.

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [x] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [x] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
