### PR TITLE
feat: Replace mute role assignments with Discord timeouts for mutes

### DIFF
--- a/src/discord/spam.py
+++ b/src/discord/spam.py
@@ -126,7 +126,7 @@ class SpamManager(commands.Cog):
         """
         unmute_time = discord.utils.utcnow() + datetime.timedelta(hours=1)
 
-        await member.timeout(unmute_time, reason="Automatic")
+        await member.timeout(unmute_time, reason="Automatic - spam")
 
     async def store_and_validate(self, message: discord.Message) -> None:
         """

--- a/src/discord/spam.py
+++ b/src/discord/spam.py
@@ -6,13 +6,9 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands
 
-from env import env
-from src.discord.globals import ROLE_MUTED
-
 if TYPE_CHECKING:
     from bot import PiBot
     from src.discord.reporter import Reporter
-    from src.discord.tasks import CronTasks
 
 
 class SpamManager(commands.Cog):
@@ -128,16 +124,9 @@ class SpamManager(commands.Cog):
         """
         Mutes the user and schedules an unmute for an hour later in CRON.
         """
-        guild: discord.Guild = self.bot.get_guild(env.server_id)
-        muted_role = discord.utils.get(guild.roles, name=ROLE_MUTED)
         unmute_time = discord.utils.utcnow() + datetime.timedelta(hours=1)
 
-        # Type checking
-        assert isinstance(muted_role, discord.Role)
-
-        cron_cog: commands.Cog | CronTasks = self.bot.get_cog("CronTasks")
-        await cron_cog.schedule_unmute(member, unmute_time)
-        await member.add_roles(muted_role)
+        await member.timeout(unmute_time, reason="Automatic")
 
     async def store_and_validate(self, message: discord.Message) -> None:
         """

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -684,7 +684,7 @@ class StaffEssential(StaffCommands):
     )
     async def mute(
         self,
-        interaction,
+        interaction: discord.Interaction,
         member: discord.Member,
         reason: str,
         mute_length: Literal[

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -686,7 +686,7 @@ class StaffEssential(StaffCommands):
         self,
         interaction: discord.Interaction,
         member: discord.Member,
-        reason: str,
+        reason: str | None,
         mute_length: Literal[
             "10 minutes",
             "30 minutes",

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -787,13 +787,24 @@ class StaffEssential(StaffCommands):
                 pass
 
         # Test
-        if member.timed_out_until:
-            # User was successfully muted
+        if not member.timed_out_until or member.timed_out_until != selected_time:
+            timeout_str = (
+                f"timeout that ends {discord.utils.format_dt(member.timed_out_until)} ({discord.utils.format_dt(member.timed_out_until, style='R')})"
+                if member.timed_out_until
+                else "no timeout that was applied."
+            )
             await interaction.edit_original_response(
-                content="The user was successfully muted.",
+                content=f"Test for timeout failed. Found {timeout_str}",
                 embed=None,
                 view=None,
             )
+            return
+        # User was successfully muted
+        await interaction.edit_original_response(
+            content="The user was successfully muted.",
+            embed=None,
+            view=None,
+        )
 
     @app_commands.command(
         description="Staff command. Allows staff to manipulate the CRON list.",

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -485,8 +485,16 @@ class StaffEssential(StaffCommands):
     @app_commands.checks.has_any_role(ROLE_STAFF, ROLE_VIP)
     @app_commands.default_permissions(manage_roles=True)
     @app_commands.guilds(*env.slash_command_guilds)
-    @app_commands.describe(member="The user to unmute.")
-    async def unmute(self, interaction: discord.Interaction, member: discord.Member):
+    @app_commands.describe(
+        member="The user to unmute.",
+        reason="The reason to unmute the user.",
+    )
+    async def unmute(
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+        reason: str | None,
+    ):
         """Unmutes a user."""
         # Check caller is staff
         commandchecks.is_staff_from_ctx(interaction)
@@ -522,7 +530,10 @@ class StaffEssential(StaffCommands):
         # Handle response
         if view.value:
             try:
-                await member.timeout(None)
+                await member.timeout(
+                    None,
+                    reason=generate_audit_reason_message(interaction, reason),
+                )
             except Exception:
                 logger.exception("Unable to remove the Muted role from a given user.")
 

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -459,7 +459,9 @@ class StaffEssential(StaffCommands):
                         "Notice from the Scioly.org server:",
                         embed=alert_embed,
                     )
-                await member.kick(reason=reason)
+                await member.kick(
+                    reason=generate_audit_reason_message(interaction, reason),
+                )
             except Exception:
                 pass
 
@@ -646,7 +648,7 @@ class StaffEssential(StaffCommands):
                 # Ban member
                 await interaction.guild.ban(
                     member,
-                    reason=reason,
+                    reason=generate_audit_reason_message(interaction, reason),
                     delete_message_days=delete_days,
                 )
             except Exception:

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -783,8 +783,8 @@ class StaffEssential(StaffCommands):
                     selected_time,
                     reason=generate_audit_reason_message(interaction, reason),
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(e)
 
         # Test
         if not member.timed_out_until or member.timed_out_until != selected_time:

--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -745,7 +745,10 @@ class StaffEssential(StaffCommands):
                         "Notice from the Scioly.org server:",
                         embed=alert_embed,
                     )
-                await member.timeout(selected_time, reason=reason)
+                await member.timeout(
+                    selected_time,
+                    reason=generate_audit_reason_message(interaction, reason),
+                )
             except Exception:
                 pass
 
@@ -1375,6 +1378,16 @@ class StaffNonessential(StaffCommands, name="StaffNonesntl"):
         # Reset bot status to regularly update
         cron_cog: commands.Cog | CronTasks = self.bot.get_cog("CronTasks")
         cron_cog.change_bot_status.restart()
+
+
+def generate_audit_reason_message(
+    interaction: discord.Interaction,
+    reason: str | None,
+) -> str:
+    full_reason = f"On behalf of `{interaction.user.name}` ({interaction.user.mention})"
+    if reason:
+        full_reason += f" - {reason}"
+    return full_reason
 
 
 async def setup(bot: PiBot):


### PR DESCRIPTION
# Description
Replaces majority references to Mute role with using Discord's built-in timeouts.
These get logged to the audit log automatically, get shown in modview for the applicable user, and are fully managed by Discord. Pi-Bot does not need a cron job to unmute users.

Old cron job code for unmuting users is still present in order to prevent potential breaking changes on redeploy.

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [x] I added docstrings to **any** new modules, classes, and methods.
- [x] I updated the docstrings of **any** updated modules, classes, and methods.
- [x] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
