### PR TITLE
fix: Fix issues within `/mute`

### DIFF
--- a/src/discord/staffcommands.py
+++ b/src/discord/staffcommands.py
@@ -745,6 +745,11 @@ class StaffEssential(StaffCommands):
             selected_time = self.time_str_to_datetime(mute_length)
             time_statement = f"The user will be muted until {discord.utils.format_dt(selected_time)}."
         if until:
+            if until <= datetime.datetime.now(tz=datetime.timezone.utc).timestamp():
+                raise Exception(
+                    "`until` unix timestamp must be set in the future. No timeout will be applied otherwise.",
+                )
+
             selected_time = datetime.datetime.fromtimestamp(
                 until,
                 tz=datetime.timezone.utc,
@@ -783,6 +788,13 @@ class StaffEssential(StaffCommands):
                 content="Cancelled",
                 embed=None,
                 view=None,
+            )
+            return
+        if selected_time and selected_time <= datetime.datetime.now(
+            tz=datetime.timezone.utc,
+        ):
+            await interaction.edit_original_response(
+                content="Proposed expiration timestamp is now set in the past. No timeout will be applied.",
             )
             return
         muted_role = discord.utils.get(interaction.guild.roles, name=ROLE_MUTED)


### PR DESCRIPTION
# Description
Fixes a couple of issues within `/mute`:
- Changes test logic  to fetch the new member object rather than referencing the old one.
  - The old one is cached data and doesn't represent the most up-to-date state after timing out the user.
- Add a check to make sure the timestamp provided and used after confirmation is in the future.
  - No timeout would be applied otherwise

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
